### PR TITLE
Add onboarding features and core services

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <application
         android:label="wing"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/example/wing/OverlayService.kt
+++ b/android/app/src/main/kotlin/com/example/wing/OverlayService.kt
@@ -1,0 +1,9 @@
+package com.example.wing
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+class OverlayService : Service() {
+  override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'profile_creation_screen.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -30,7 +31,10 @@ class HomeScreen extends StatelessWidget {
               const SizedBox(height: 32),
               ElevatedButton(
                 onPressed: () {
-                  // בהמשך נוסיף מעבר למסך הבא
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ProfileCreationScreen()),
+                  );
                 },
                 child: const Text('Get Started'),
               ),

--- a/lib/screens/profile_creation_screen.dart
+++ b/lib/screens/profile_creation_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+class ProfileCreationScreen extends StatefulWidget {
+  const ProfileCreationScreen({super.key});
+
+  @override
+  State<ProfileCreationScreen> createState() => _ProfileCreationScreenState();
+}
+
+class _ProfileCreationScreenState extends State<ProfileCreationScreen> {
+  final _formKey = GlobalKey<FormState>();
+  bool connectTinder = false;
+  bool connectBumble = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Profile')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('Tell us about yourself'),
+              TextFormField(
+                decoration: const InputDecoration(
+                  labelText: 'Describe your personality',
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                decoration: const InputDecoration(
+                  labelText: 'What are you looking for?',
+                ),
+              ),
+              const SizedBox(height: 16),
+              const Text('Dating Preferences'),
+              Row(
+                children: [
+                  const Text('Interested in:'),
+                  const SizedBox(width: 8),
+                  DropdownButton<String>(
+                    items: const [
+                      DropdownMenuItem(value: 'men', child: Text('Men')),
+                      DropdownMenuItem(value: 'women', child: Text('Women')),
+                      DropdownMenuItem(value: 'everyone', child: Text('Everyone')),
+                    ],
+                    onChanged: (_) {},
+                  ),
+                ],
+              ),
+              RangeSlider(
+                values: const RangeValues(18, 35),
+                min: 18,
+                max: 100,
+                onChanged: (v) {},
+                labels: const RangeLabels('18', '35'),
+              ),
+              const SizedBox(height: 16),
+              const Text('Connect Accounts'),
+              SwitchListTile(
+                title: const Text('Tinder'),
+                value: connectTinder,
+                onChanged: (v) => setState(() => connectTinder = v),
+              ),
+              SwitchListTile(
+                title: const Text('Bumble'),
+                value: connectBumble,
+                onChanged: (v) => setState(() => connectBumble = v),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    Navigator.pop(context);
+                  }
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/analysis_service.dart
+++ b/lib/services/analysis_service.dart
@@ -1,0 +1,7 @@
+class AnalysisService {
+  Future<String> analyzeText(String text) async {
+    // TODO: integrate OpenAI or local LLM
+    await Future.delayed(const Duration(milliseconds: 500));
+    return 'Analysis result for: \$text';
+  }
+}

--- a/lib/services/ocr_service.dart
+++ b/lib/services/ocr_service.dart
@@ -1,0 +1,12 @@
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+import 'dart:io';
+
+class OcrService {
+  final textRecognizer = TextRecognizer();
+
+  Future<String> processImage(File image) async {
+    final inputImage = InputImage.fromFile(image);
+    final result = await textRecognizer.processImage(inputImage);
+    return result.text;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  google_mlkit_text_recognition: ^0.7.0
+  permission_handler: ^11.0.0
+  flutter_overlay_window: ^0.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add MLKit OCR, overlay, and permission dependencies
- expand home screen to launch new profile creation flow
- create profile creation screen with preferences and app toggles
- scaffold OCR and analysis services
- stub Android overlay service and permission

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688d55caf1e88326ba01593b087d667b