### PR TITLE
fix: remove const from WingChatScreen navigation

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -46,7 +46,7 @@ class HomeScreen extends StatelessWidget {
               ElevatedButton(
                 onPressed: () {
                   Navigator.push(context,
-                    MaterialPageRoute(builder: (_) => const WingChatScreen()));
+                    MaterialPageRoute(builder: (_) => WingChatScreen()));
                 },
                 child: const Text("Chat with Wing"),
               ),


### PR DESCRIPTION
## Summary
- call `WingChatScreen()` without const since constructor isn't const

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e0442a954832693ca2ba04b7bf7f5