### PR TITLE
refactor: make WingChatScreen stateful

### DIFF
--- a/lib/screens/wing_chat_screen.dart
+++ b/lib/screens/wing_chat_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+class WingChatScreen extends StatefulWidget {
+  const WingChatScreen({super.key});
+
+  @override
+  State<WingChatScreen> createState() => _WingChatScreenState();
+}
+
+class _WingChatScreenState extends State<WingChatScreen> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chat with Wing'),
+      ),
+      body: Column(
+        children: [
+          const Expanded(
+            child: SizedBox(),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration: const InputDecoration(
+                      hintText: 'Type a message',
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.send),
+                  onPressed: () {
+                    // TODO: implement send functionality
+                    _controller.clear();
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- convert WingChatScreen to a StatefulWidget
- manage TextEditingController lifecycle with initState and dispose

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e063d86888326bd1e6a37ab8d7de2