### PR TITLE
feat: request screen capture permission

### DIFF
--- a/lib/screens/activate_wing_screen.dart
+++ b/lib/screens/activate_wing_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class ActivateWingScreen extends StatelessWidget {
+  const ActivateWingScreen({super.key});
+
+  Future<void> _requestScreenCapturePermission(BuildContext context) async {
+    final status = await Permission.photos.request();
+    if (!status.isGranted) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Screen capture permission denied')),
+        );
+      }
+      return;
+    }
+    // TODO: Add screen capture activation logic here
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Activate Wing'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => _requestScreenCapturePermission(context),
+          child: const Text('Request Screen Capture Permission'),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  permission_handler: ^11.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Activate Wing screen with screen capture permission request
- show user feedback when permission is denied
- include permission_handler dependency

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e063fed948326a22cbeaf6eaa810f