### PR TITLE
feat: move shared_preferences to dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
-  shared_preferences: ^2.2.2
   
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- move shared_preferences package from dev to prod dependencies

## Testing
- `flutter pub get` *(fails: command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_688e0b0e381483269bf6c1531575680e