### PR TITLE
Implement missing screens referenced by HomeScreen

### DIFF
--- a/lib/screens/activate_wing_screen.dart
+++ b/lib/screens/activate_wing_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ActivateWingScreen extends StatelessWidget {
+  const ActivateWingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Activate Wing'),
+      ),
+      body: const Center(
+        child: Text('Activate Wing Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/matches_screen.dart
+++ b/lib/screens/matches_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class MatchesScreen extends StatelessWidget {
+  const MatchesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Matches'),
+      ),
+      body: const Center(
+        child: Text('Matches Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Profile'),
+      ),
+      body: const Center(
+        child: Text('Profile Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/wing_chat_screen.dart
+++ b/lib/screens/wing_chat_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class WingChatScreen extends StatelessWidget {
+  const WingChatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wing Chat'),
+      ),
+      body: const Center(
+        child: Text('Wing Chat Screen'),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add placeholder screens for profile, matches, activation, and chat

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e2a9e0b748326bc7210dbbb2334ba