### PR TITLE
Center loading spinner during startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,9 @@ class WingApp extends StatelessWidget {
         future: checkIfProfileCompleted(),
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
-            return const CircularProgressIndicator(); // טעינה
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            ); // טעינה
           }
           return snapshot.data! ? const HomeScreen() : const ProfileSetupScreen();
         },


### PR DESCRIPTION
## Summary
- wrap loading indicator in a Scaffold with Center to display a centered spinner while prefs load

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e2aa2d66c8326baec96b5cdf1d618