### PR TITLE
Convert WingApp to StatefulWidget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,12 +8,25 @@ void main() {
   runApp(const WingApp());
 }
 
-class WingApp extends StatelessWidget {
+class WingApp extends StatefulWidget {
   const WingApp({super.key});
+
+  @override
+  State<WingApp> createState() => _WingAppState();
+}
+
+class _WingAppState extends State<WingApp> {
+  late Future<bool> _profileCompletedFuture;
 
   Future<bool> checkIfProfileCompleted() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool('hasCompletedSetup') ?? false;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _profileCompletedFuture = checkIfProfileCompleted();
   }
 
   @override
@@ -25,7 +38,7 @@ class WingApp extends StatelessWidget {
         useMaterial3: true,
       ),
       home: FutureBuilder<bool>(
-        future: checkIfProfileCompleted(),
+        future: _profileCompletedFuture,
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
             return const CircularProgressIndicator(); // טעינה


### PR DESCRIPTION
## Summary
- convert WingApp from `StatelessWidget` to `StatefulWidget`
- cache the profile completion Future in `initState`
- reuse cached Future in `FutureBuilder` to avoid repeated calls

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688e2aafd4a883269ed2e6a1f8e9af2b