### PR TITLE
Add multilingual support

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static const supportedLocales = [
+    Locale('en'),
+    Locale('es'),
+    Locale('de'),
+    Locale('he'),
+    Locale('ru'),
+    Locale('ar'),
+  ];
+
+  static const Map<String, String> languageNames = {
+    'en': 'English',
+    'es': 'Español',
+    'de': 'Deutsch',
+    'he': 'עברית',
+    'ru': 'Русский',
+    'ar': 'العربية',
+  };
+
+  static const Map<String, Map<String, String>> _localizedValues = {
+    'en': {
+      'appTitle': 'Wing',
+      'myProfile': 'My Profile',
+      'myMatches': 'My Matches',
+      'activateWing': 'Activate Wing',
+      'chatWithWing': 'Chat with Wing',
+      'setupProfile': 'Set up your profile',
+      'nameLabel': 'Name',
+      'nameValidation': 'Please enter your name',
+      'genderLabel': 'Your gender',
+      'lookingForLabel': 'Looking for',
+      'continue': 'Continue',
+      'male': 'Male',
+      'female': 'Female',
+      'other': 'Other',
+      'both': 'Both',
+      'any': 'Any',
+      'language': 'Language',
+    },
+    'es': {
+      'appTitle': 'Wing',
+      'myProfile': 'Mi perfil',
+      'myMatches': 'Mis coincidencias',
+      'activateWing': 'Activar Wing',
+      'chatWithWing': 'Chatear con Wing',
+      'setupProfile': 'Configura tu perfil',
+      'nameLabel': 'Nombre',
+      'nameValidation': 'Por favor ingresa tu nombre',
+      'genderLabel': 'Tu género',
+      'lookingForLabel': 'Buscando',
+      'continue': 'Continuar',
+      'male': 'Hombre',
+      'female': 'Mujer',
+      'other': 'Otro',
+      'both': 'Ambos',
+      'any': 'Cualquiera',
+      'language': 'Idioma',
+    },
+    'de': {
+      'appTitle': 'Wing',
+      'myProfile': 'Mein Profil',
+      'myMatches': 'Meine Matches',
+      'activateWing': 'Wing aktivieren',
+      'chatWithWing': 'Mit Wing chatten',
+      'setupProfile': 'Richte dein Profil ein',
+      'nameLabel': 'Name',
+      'nameValidation': 'Bitte gib deinen Namen ein',
+      'genderLabel': 'Dein Geschlecht',
+      'lookingForLabel': 'Suche nach',
+      'continue': 'Weiter',
+      'male': 'Männlich',
+      'female': 'Weiblich',
+      'other': 'Andere',
+      'both': 'Beide',
+      'any': 'Beliebig',
+      'language': 'Sprache',
+    },
+    'he': {
+      'appTitle': 'Wing',
+      'myProfile': 'הפרופיל שלי',
+      'myMatches': 'ההתאמות שלי',
+      'activateWing': 'הפעל את Wing',
+      'chatWithWing': 'שוחח עם Wing',
+      'setupProfile': 'הגדר את הפרופיל שלך',
+      'nameLabel': 'שם',
+      'nameValidation': 'אנא הזן את שמך',
+      'genderLabel': 'המגדר שלך',
+      'lookingForLabel': 'מחפש/ת',
+      'continue': 'המשך',
+      'male': 'זכר',
+      'female': 'נקבה',
+      'other': 'אחר',
+      'both': 'שניהם',
+      'any': 'כל אחד',
+      'language': 'שפה',
+    },
+    'ru': {
+      'appTitle': 'Wing',
+      'myProfile': 'Мой профиль',
+      'myMatches': 'Мои совпадения',
+      'activateWing': 'Активировать Wing',
+      'chatWithWing': 'Чат с Wing',
+      'setupProfile': 'Настройте свой профиль',
+      'nameLabel': 'Имя',
+      'nameValidation': 'Пожалуйста, введите ваше имя',
+      'genderLabel': 'Ваш пол',
+      'lookingForLabel': 'Ищу',
+      'continue': 'Продолжить',
+      'male': 'Мужской',
+      'female': 'Женский',
+      'other': 'Другой',
+      'both': 'Оба',
+      'any': 'Любой',
+      'language': 'Язык',
+    },
+    'ar': {
+      'appTitle': 'Wing',
+      'myProfile': 'ملفي الشخصي',
+      'myMatches': 'تطابقي',
+      'activateWing': 'فعّل Wing',
+      'chatWithWing': 'تحدث مع Wing',
+      'setupProfile': 'أعد إعداد ملفك الشخصي',
+      'nameLabel': 'الاسم',
+      'nameValidation': 'يرجى إدخال اسمك',
+      'genderLabel': 'جنسك',
+      'lookingForLabel': 'يبحث عن',
+      'continue': 'متابعة',
+      'male': 'ذكر',
+      'female': 'أنثى',
+      'other': 'آخر',
+      'both': 'كلاهما',
+      'any': 'أي',
+      'language': 'اللغة',
+    },
+  };
+
+  String translate(String key) {
+    return _localizedValues[locale.languageCode]?[key] ?? key;
+  }
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) =>
+      ['en', 'es', 'de', 'he', 'ru', 'ar'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}

--- a/lib/locale_provider.dart
+++ b/lib/locale_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final ValueNotifier<Locale> localeNotifier = ValueNotifier(const Locale('en'));
+
+Future<void> loadLocale() async {
+  final prefs = await SharedPreferences.getInstance();
+  final code = prefs.getString('languageCode') ?? 'en';
+  localeNotifier.value = Locale(code);
+}
+
+Future<void> updateLocale(Locale locale) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString('languageCode', locale.languageCode);
+  localeNotifier.value = locale;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'l10n/app_localizations.dart';
+import 'locale_provider.dart';
 import 'screens/profile_setup_screen.dart';
 import 'screens/home_screen.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await loadLocale();
   runApp(const WingApp());
 }
 
@@ -18,21 +23,34 @@ class WingApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Wing',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.purple),
-        useMaterial3: true,
-      ),
-      home: FutureBuilder<bool>(
-        future: checkIfProfileCompleted(),
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
-            return const CircularProgressIndicator(); // טעינה
-          }
-          return snapshot.data! ? const HomeScreen() : const ProfileSetupScreen();
-        },
-      ),
+    return ValueListenableBuilder<Locale>(
+      valueListenable: localeNotifier,
+      builder: (context, locale, _) {
+        return MaterialApp(
+          title: 'Wing',
+          locale: locale,
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(seedColor: Colors.purple),
+            useMaterial3: true,
+          ),
+          home: FutureBuilder<bool>(
+            future: checkIfProfileCompleted(),
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const CircularProgressIndicator();
+              }
+              return snapshot.data! ? const HomeScreen() : const ProfileSetupScreen();
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+
+import '../l10n/app_localizations.dart';
+import '../locale_provider.dart' as locale_provider;
 import 'profile_screen.dart';
 import 'matches_screen.dart';
 import 'activate_wing_screen.dart';
@@ -9,9 +12,24 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Wing'),
+        title: Text(localizations.translate('appTitle')),
+        actions: [
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.language),
+            onSelected: (code) => locale_provider.updateLocale(Locale(code)),
+            itemBuilder: (context) => AppLocalizations.languageNames.entries
+                .map(
+                  (e) => PopupMenuItem(
+                    value: e.key,
+                    child: Text(e.value),
+                  ),
+                )
+                .toList(),
+          ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(24.0),
@@ -21,34 +39,43 @@ class HomeScreen extends StatelessWidget {
             children: [
               ElevatedButton(
                 onPressed: () {
-                  Navigator.push(context,
-                    MaterialPageRoute(builder: (_) => const ProfileScreen()));
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ProfileScreen()),
+                  );
                 },
-                child: const Text("My Profile"),
+                child: Text(localizations.translate('myProfile')),
               ),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () {
-                  Navigator.push(context,
-                    MaterialPageRoute(builder: (_) => const MatchesScreen()));
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const MatchesScreen()),
+                  );
                 },
-                child: const Text("My Matches"),
+                child: Text(localizations.translate('myMatches')),
               ),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () {
-                  Navigator.push(context,
-                    MaterialPageRoute(builder: (_) => const ActivateWingScreen()));
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const ActivateWingScreen()),
+                  );
                 },
-                child: const Text("Activate Wing"),
+                child: Text(localizations.translate('activateWing')),
               ),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () {
-                  Navigator.push(context,
-                    MaterialPageRoute(builder: (_) => const WingChatScreen()));
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const WingChatScreen()),
+                  );
                 },
-                child: const Text("Chat with Wing"),
+                child: Text(localizations.translate('chatWithWing')),
               ),
             ],
           ),

--- a/lib/screens/profile_setup_screen.dart
+++ b/lib/screens/profile_setup_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../l10n/app_localizations.dart';
+import '../locale_provider.dart' as locale_provider;
 import 'home_screen.dart';
 
 class ProfileSetupScreen extends StatefulWidget {
@@ -12,50 +15,77 @@ class ProfileSetupScreen extends StatefulWidget {
 class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
   final _formKey = GlobalKey<FormState>();
   String name = '';
-  String gender = 'Other';
-  String lookingFor = 'Any';
+  String gender = 'other';
+  String lookingFor = 'any';
+  String languageCode = locale_provider.localeNotifier.value.languageCode;
 
-  final List<String> genders = ['Male', 'Female', 'Other'];
-  final List<String> preferences = ['Male', 'Female', 'Both', 'Any'];
+  final List<String> genders = ['male', 'female', 'other'];
+  final List<String> preferences = ['male', 'female', 'both', 'any'];
 
   @override
   Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text("Set up your profile")),
+      appBar: AppBar(title: Text(localizations.translate('setupProfile'))),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Form(
           key: _formKey,
           child: Column(
             children: [
+              DropdownButtonFormField<String>(
+                decoration:
+                    InputDecoration(labelText: localizations.translate('language')),
+                value: languageCode,
+                items: AppLocalizations.languageNames.entries
+                    .map(
+                      (e) => DropdownMenuItem(
+                        value: e.key,
+                        child: Text(e.value),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) {
+                  setState(() => languageCode = value!);
+                  locale_provider.updateLocale(Locale(value!));
+                },
+              ),
+              const SizedBox(height: 16),
               TextFormField(
-                decoration: const InputDecoration(labelText: 'Name'),
+                decoration:
+                    InputDecoration(labelText: localizations.translate('nameLabel')),
                 validator: (value) => (value == null || value.isEmpty)
-                    ? 'Please enter your name'
+                    ? localizations.translate('nameValidation')
                     : null,
                 onSaved: (value) => name = value!,
               ),
               const SizedBox(height: 16),
               DropdownButtonFormField<String>(
-                decoration: const InputDecoration(labelText: 'Your gender'),
+                decoration:
+                    InputDecoration(labelText: localizations.translate('genderLabel')),
                 value: gender,
                 items: genders
-                    .map((g) => DropdownMenuItem(
-                          value: g,
-                          child: Text(g),
-                        ))
+                    .map(
+                      (g) => DropdownMenuItem(
+                        value: g,
+                        child: Text(localizations.translate(g)),
+                      ),
+                    )
                     .toList(),
                 onChanged: (value) => setState(() => gender = value!),
               ),
               const SizedBox(height: 16),
               DropdownButtonFormField<String>(
-                decoration: const InputDecoration(labelText: 'Looking for'),
+                decoration: InputDecoration(
+                    labelText: localizations.translate('lookingForLabel')),
                 value: lookingFor,
                 items: preferences
-                    .map((p) => DropdownMenuItem(
-                          value: p,
-                          child: Text(p),
-                        ))
+                    .map(
+                      (p) => DropdownMenuItem(
+                        value: p,
+                        child: Text(localizations.translate(p)),
+                      ),
+                    )
                     .toList(),
                 onChanged: (value) => setState(() => lookingFor = value!),
               ),
@@ -76,7 +106,7 @@ class _ProfileSetupScreenState extends State<ProfileSetupScreen> {
                     );
                   }
                 },
-                child: const Text('Continue'),
+                child: Text(localizations.translate('continue')),
               )
             ],
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,12 +9,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
-  shared_preferences: ^2.2.2
   
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- enable runtime language selection with persistent locale storage
- wire MaterialApp localization with six supported languages
- translate existing UI strings and expose language pickers

## Testing
- `dart format lib/main.dart lib/screens/home_screen.dart lib/screens/profile_setup_screen.dart lib/locale_provider.dart lib/l10n/app_localizations.dart pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6890589def9083269551b3f1a66c5272